### PR TITLE
Reduce bullet list left padding on mobile

### DIFF
--- a/src/components/layout/SectionedList.jsx
+++ b/src/components/layout/SectionedList.jsx
@@ -13,6 +13,12 @@ const StyledSectionedList = styled.div`
     list-style-type: disc;
     margin-top: 8px;
   }
+
+  @media only screen and (max-width: 576px) {
+    .section-list {
+      padding-left: 20px;
+    }
+  }
 `;
 
 const SectionedList = ({ header, date, list }) => (


### PR DESCRIPTION
Shrinks ul padding-left from browser default 40px to 20px on screens
≤576px to recover horizontal space on narrow viewports.

https://claude.ai/code/session_01MLVZhVhaaHTBKL4uWtnRhx