### PR TITLE
Merge CV download link into technologies panel

### DIFF
--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -34,7 +34,9 @@ const Footer = () => (
       >
         LinkedIn
       </Link>
-      <Link href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf">CV</Link>
+      <Link href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf" download>
+        CV
+      </Link>
       <Link href="/privacy">Privacy Policy</Link>
     </Links>
   </StyledFooter>

--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -34,9 +34,7 @@ const Footer = () => (
       >
         LinkedIn
       </Link>
-      <Link href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf" download>
-        CV
-      </Link>
+      <Link href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf">CV</Link>
       <Link href="/privacy">Privacy Policy</Link>
     </Links>
   </StyledFooter>

--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -34,6 +34,7 @@ const Footer = () => (
       >
         LinkedIn
       </Link>
+      <Link href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf">CV</Link>
       <Link href="/privacy">Privacy Policy</Link>
     </Links>
   </StyledFooter>

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 const StyledButton = styled.a`
   display: inline-block;
-  padding: 10px 20px;
+  padding: 10px 15px;
   border: 1px solid var(--color-secondary);
   border-radius: 8px;
   color: var(--color-text);

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const StyledButton = styled.a`
+  display: inline-block;
+  padding: 10px 20px;
+  border: 1px solid var(--color-secondary);
+  border-radius: 8px;
+  color: var(--color-text);
+  text-decoration: none;
+  transition:
+    color 0.3s,
+    border-color 0.3s;
+
+  &:hover {
+    color: var(--color-text-link-hover);
+    border-color: var(--color-text-link-hover);
+  }
+`;
+
+const Button = ({ href, openInNewTab = false, download = false, children }) => (
+  <StyledButton
+    href={href}
+    target={openInNewTab ? "_blank" : undefined}
+    rel={openInNewTab ? "noopener noreferrer" : undefined}
+    download={download || undefined}
+  >
+    {children}
+  </StyledButton>
+);
+
+Button.propTypes = {
+  href: PropTypes.string.isRequired,
+  openInNewTab: PropTypes.bool,
+  download: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+export default Button;

--- a/src/components/ui/Link.jsx
+++ b/src/components/ui/Link.jsx
@@ -11,12 +11,11 @@ const StyledLink = styled.a`
   }
 `;
 
-const Link = ({ href, openInNewTab = false, download = false, children }) => (
+const Link = ({ href, openInNewTab = false, children }) => (
   <StyledLink
     href={href}
     target={openInNewTab ? "_blank" : undefined}
     rel={openInNewTab ? "noopener noreferrer" : undefined}
-    download={download || undefined}
   >
     {children}
   </StyledLink>
@@ -25,7 +24,6 @@ const Link = ({ href, openInNewTab = false, download = false, children }) => (
 Link.propTypes = {
   href: PropTypes.string.isRequired,
   openInNewTab: PropTypes.bool,
-  download: PropTypes.bool,
   children: PropTypes.node.isRequired,
 };
 

--- a/src/components/ui/Link.jsx
+++ b/src/components/ui/Link.jsx
@@ -11,11 +11,12 @@ const StyledLink = styled.a`
   }
 `;
 
-const Link = ({ href, openInNewTab = false, children }) => (
+const Link = ({ href, openInNewTab = false, download = false, children }) => (
   <StyledLink
     href={href}
     target={openInNewTab ? "_blank" : undefined}
     rel={openInNewTab ? "noopener noreferrer" : undefined}
+    download={download || undefined}
   >
     {children}
   </StyledLink>
@@ -24,6 +25,7 @@ const Link = ({ href, openInNewTab = false, children }) => (
 Link.propTypes = {
   href: PropTypes.string.isRequired,
   openInNewTab: PropTypes.bool,
+  download: PropTypes.bool,
   children: PropTypes.node.isRequired,
 };
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -5,6 +5,7 @@ import Panel from "../components/layout/Panel";
 import Icon from "../components/ui/Icon";
 import SectionedList from "../components/layout/SectionedList";
 import Link from "../components/ui/Link";
+import Button from "../components/ui/Button";
 
 const About = styled.div`
   .experience-company {
@@ -24,22 +25,8 @@ const About = styled.div`
   }
 
   .cv-download {
-    display: block;
-    width: fit-content;
-    margin: 20px auto 0;
-    padding: 10px 20px;
-    border: 1px solid var(--color-secondary);
-    border-radius: 8px;
-    color: var(--color-text);
-    text-decoration: none;
-    transition:
-      color 0.3s,
-      border-color 0.3s;
-
-    &:hover {
-      color: var(--color-text-link-hover);
-      border-color: var(--color-text-link-hover);
-    }
+    text-align: center;
+    margin-top: 20px;
   }
 
   @media only screen and (max-width: 576px) {
@@ -158,13 +145,14 @@ const AboutPage = () => (
           ))}
         </div>
         <div className="technologies-more">... and many, many more.</div>
-        <a
-          href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf"
-          className="cv-download"
-          download
-        >
-          Download CV (PDF)
-        </a>
+        <div className="cv-download">
+          <Button
+            href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf"
+            download
+          >
+            Download CV (PDF)
+          </Button>
+        </div>
       </Panel>
 
       <Panel title="education">

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -23,10 +23,6 @@ const About = styled.div`
     margin-top: 15px;
   }
 
-  .resume-download {
-    text-align: center;
-  }
-
   @media only screen and (max-width: 576px) {
     .technologies-more {
       text-align: center;
@@ -143,18 +139,9 @@ const AboutPage = () => (
           ))}
         </div>
         <div className="technologies-more">
-          ... and many, many more:{" "}
+          ... and many, many more — see my{" "}
           <Link href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf">
-            see resume
-          </Link>
-          .
-        </div>
-      </Panel>
-
-      <Panel title="resume">
-        <div className="resume-download">
-          <Link href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf">
-            Download my CV (PDF)
+            CV (PDF)
           </Link>
           .
         </div>

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -23,6 +23,28 @@ const About = styled.div`
     margin-top: 15px;
   }
 
+  .cv-download {
+    display: inline-block;
+    margin-top: 20px;
+    padding: 10px 20px;
+    border: 1px solid var(--color-text);
+    border-radius: 4px;
+    color: var(--color-text);
+    text-decoration: none;
+    transition:
+      color 0.3s,
+      border-color 0.3s;
+
+    &:hover {
+      color: var(--color-text-link-hover);
+      border-color: var(--color-text-link-hover);
+    }
+  }
+
+  .cv-download-wrapper {
+    text-align: center;
+  }
+
   @media only screen and (max-width: 576px) {
     .technologies-more {
       text-align: center;
@@ -138,12 +160,15 @@ const AboutPage = () => (
             <Icon key={index} iconName={tech.iconName} label={tech.label} />
           ))}
         </div>
-        <div className="technologies-more">
-          ... and many, many more — see my{" "}
-          <Link href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf">
-            CV (PDF)
-          </Link>
-          .
+        <div className="technologies-more">... and many, many more.</div>
+        <div className="cv-download-wrapper">
+          <a
+            href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf"
+            className="cv-download"
+            download
+          >
+            Download CV (PDF)
+          </a>
         </div>
       </Panel>
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -144,14 +144,21 @@ const AboutPage = () => (
             <Icon key={index} iconName={tech.iconName} label={tech.label} />
           ))}
         </div>
-        <div className="technologies-more">... and many, many more.</div>
-        <div className="cv-download">
-          <Button
-            href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf"
-            download
-          >
-            Download CV (PDF)
+        <div className="technologies-more">
+          ... and many more. See the full list in my CV -{" "}
+          <Button href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf" download>
+            Download PDF
           </Button>
+          <div>
+            or{" "}
+            <Link
+              href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf"
+              openInNewTab
+            >
+              open the CV in browser
+            </Link>
+            .
+          </div>
         </div>
       </Panel>
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -24,11 +24,12 @@ const About = styled.div`
   }
 
   .cv-download {
-    display: inline-block;
-    margin-top: 20px;
+    display: block;
+    width: fit-content;
+    margin: 20px auto 0;
     padding: 10px 20px;
-    border: 1px solid var(--color-text);
-    border-radius: 4px;
+    border: 1px solid var(--color-secondary);
+    border-radius: 8px;
     color: var(--color-text);
     text-decoration: none;
     transition:
@@ -39,10 +40,6 @@ const About = styled.div`
       color: var(--color-text-link-hover);
       border-color: var(--color-text-link-hover);
     }
-  }
-
-  .cv-download-wrapper {
-    text-align: center;
   }
 
   @media only screen and (max-width: 576px) {
@@ -161,15 +158,13 @@ const AboutPage = () => (
           ))}
         </div>
         <div className="technologies-more">... and many, many more.</div>
-        <div className="cv-download-wrapper">
-          <a
-            href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf"
-            className="cv-download"
-            download
-          >
-            Download CV (PDF)
-          </a>
-        </div>
+        <a
+          href="/Grzegorz-Golebiowski-Java-Tech-Lead-CV.pdf"
+          className="cv-download"
+          download
+        >
+          Download CV (PDF)
+        </a>
       </Panel>
 
       <Panel title="education">


### PR DESCRIPTION
Drop the standalone resume panel and surface the CV link inside the
existing "and many, many more" line in technologies — one place to
download the CV instead of two adjacent links.

https://claude.ai/code/session_01Q7gUcH71JqLVxdsr1vQxJu